### PR TITLE
Remove parser indexing to fix panics

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,10 @@ use bitcoin::secp256k1::Error as Secp256k1Error;
 /// Errors related to [`Descriptor`](crate::Descriptor).
 #[derive(Error, Debug)]
 pub enum DescriptorError {
+    /// Missing type tag
+    #[error("missing type tag")]
+    MissingTypeTag,
+
     /// Invalid descriptor type tag.
     #[error("invalid descriptor type tag: {0}")]
     InvalidDescriptorType(u8),
@@ -20,10 +24,6 @@ pub enum DescriptorError {
     /// Invalid payload length.
     #[error("invalid payload length: {0}")]
     InvalidPayloadLength(usize),
-
-    /// Invalid descriptor type tag length.
-    #[error("invalid descriptor type tag length: {0}")]
-    InvalidDescriptorTypeLength(usize),
 
     /// Hex decoding error.
     #[error("hex decoding error: {0}")]


### PR DESCRIPTION
## Description

The `Descriptor::from_bytes` parser currently panics if presented with either an empty byte slice or a slice containing exactly one byte. This is due to the use of slice indexing without careful checks.

This PR removes all indexing from the parser in order to safely reject these cases. It adds comprehensive tests.

Separately, it removes an unused error.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

None.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
