### PR TITLE
Fix: errors  `DescriptorError` derives Eq and PartialEq for comparisons

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,7 @@ use bitcoin::script::witness_program::Error as WitnessProgramError;
 use bitcoin::secp256k1::Error as Secp256k1Error;
 
 /// Errors related to [`Descriptor`](crate::Descriptor).
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum DescriptorError {
     /// Invalid descriptor type tag.
     #[error("invalid descriptor type tag: {0}")]


### PR DESCRIPTION
Hi, i was messing with the code and discovered that the errors couldn't use a `assert_eq()`, so i simply added`Eq` in `DescriptorError`s derive.
