### PR TITLE
Allow empty `OP_RETURN` payload

### DIFF
--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -84,7 +84,7 @@ impl Descriptor {
             // OP_RETURN should be less than 80 bytes.
             OP_RETURN_TYPE_TAG => {
                 let payload_len = payload.len();
-                if payload_len == 0 || payload_len > MAX_OP_RETURN_LEN {
+                if payload_len > MAX_OP_RETURN_LEN {
                     Err(DescriptorError::InvalidPayloadLength(payload_len))
                 } else {
                     Ok(Self {
@@ -326,10 +326,10 @@ mod tests {
         assert!(Descriptor::from_bytes(&bytes).is_err());
 
         // Only tag type byte
-        for tag in 0..=u8::MAX {
+        for tag in 1..=u8::MAX {
             let bytes = [tag];
 
-            // An empty payload is currently invalid for all types
+            // An empty payload is currently invalid for all types except `OP_RETURN`
             assert!(Descriptor::from_bytes(&bytes).is_err());
         }
 


### PR DESCRIPTION
## Description

An empty `OP_RETURN` payload, while trivial, should be considered valid. This PR makes it so.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

None.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Closes #21.