### PR TITLE
Update documentation for payload lengths

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ and efficiently represent standard Bitcoin output types:
 
 | Type | Payload Len | Payload Interpretation |
 | ---- | ----------- | ---------------------- |
-| 0    | ..=80       | `OP_RETURN` payload    |
+| 0    | 0..=80      | `OP_RETURN` payload    |
 | 1    | 20          | P2PKH hash             |
 | 2    | 20          | P2SH hash              |
 | 3    | 20          | P2WPKH hash            |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! | Type | Payload Len | Payload Interpretation |
 //! | ---- | ----------- | ---------------------- |
-//! | 0    | ..=80       | `OP_RETURN` payload    |
+//! | 0    | 0..=80      | `OP_RETURN` payload    |
 //! | 1    | 20          | P2PKH hash             |
 //! | 2    | 20          | P2SH hash              |
 //! | 3    | 20          | P2WPKH hash            |


### PR DESCRIPTION
## Description

Previous work in #23 allows for an empty `OP_RETURN` payload. This PR updates the documentation to make this case more clear. While its `..=80` length notation is correct, it's easy enough to use `0..=80` instead.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

None.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Follows #23.