### PR TITLE
fix: make length constants public

### DIFF
--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -19,34 +19,34 @@ use crate::error::DescriptorError;
 pub(crate) const OP_RETURN_TYPE_TAG: u8 = 0;
 
 /// Maximum length of `OP_RETURN` payload.
-pub(crate) const MAX_OP_RETURN_LEN: usize = 80;
+pub const MAX_OP_RETURN_LEN: usize = 80;
 
 /// `P2PKH` type tag.
 pub(crate) const P2PKH_TYPE_TAG: u8 = 1;
 
 /// Exact length of P2PKH payload.
-pub(crate) const P2PKH_LEN: usize = 20;
+pub const P2PKH_LEN: usize = 20;
 
 /// `P2SH` type tag.
 pub(crate) const P2SH_TYPE_TAG: u8 = 2;
 
 /// Exact length of P2SH payload.
-pub(crate) const P2SH_LEN: usize = 20;
+pub const P2SH_LEN: usize = 20;
 
 /// `P2WPKH`/`P2WSH` type tag.
 pub(crate) const P2WPKH_P2WSH_TYPE_TAG: u8 = 3;
 
 /// Exact length of P2WPKH payload.
-pub(crate) const P2WPKH_LEN: usize = 20;
+pub const P2WPKH_LEN: usize = 20;
 
 /// Exact length of P2WSH payload.
-pub(crate) const P2WSH_LEN: usize = 32;
+pub const P2WSH_LEN: usize = 32;
 
 /// `P2TR` type tag.
 pub(crate) const P2TR_TYPE_TAG: u8 = 4;
 
 /// Exact length of P2TR payload.
-pub(crate) const P2TR_LEN: usize = 32;
+pub const P2TR_LEN: usize = 32;
 
 /// A Bitcoin Output Script Descriptor (BOSD).
 ///


### PR DESCRIPTION
## Description

make the `pub(crate)` constant lengths public, i.e. `pub`.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
