### PR TITLE
Fix parsing test

### DIFF
--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -291,11 +291,14 @@ mod tests {
         assert!(Descriptor::from_bytes(&bytes).is_err());
 
         // Only tag type byte
-        for tag in 1..=u8::MAX {
+        for tag in 0..=u8::MAX {
             let bytes = [tag];
 
             // An empty payload is currently invalid for all types except `OP_RETURN`
-            assert!(Descriptor::from_bytes(&bytes).is_err());
+            match tag {
+                OP_RETURN_TYPE_TAG => assert!(Descriptor::from_bytes(&bytes).is_ok()),
+                _ => assert!(Descriptor::from_bytes(&bytes).is_err()),
+            }
         }
 
         // Invalid type tag
@@ -315,6 +318,7 @@ mod tests {
         let bytes = [4; 34];
         assert!(Descriptor::from_bytes(&bytes).is_err());
     }
+
     #[test]
     fn descriptor_to_bytes() {
         let original: &[u8; 20] = &[


### PR DESCRIPTION
## Description

The descriptor parsing unit test wasn't actually checking that `OP_RETURN` empty payloads are allowed. This PR fixes the test.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

None.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

None.
