### PR TITLE
feat!(descriptor): feature-gate X-only PK validation

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -194,6 +194,12 @@ impl From<Address> for Descriptor {
     }
 }
 
+impl From<PubkeyHash> for Descriptor {
+    fn from(pubkey_hash: PubkeyHash) -> Self {
+        Descriptor::new_p2pkh(pubkey_hash.as_ref())
+    }
+}
+
 impl From<ScriptHash> for Descriptor {
     fn from(script_hash: ScriptHash) -> Self {
         let payload: &[u8; 20] = script_hash.as_ref();
@@ -441,6 +447,22 @@ mod tests {
 
         let script = desc.to_script();
         assert!(script.is_p2tr())
+    }
+
+    #[test]
+    fn from_pubkey_hash() {
+        // P2PKH
+        // Using 0x01 (type_tag) and a 20-byte hash
+        // Source: transaction 8bae12b5f4c088d940733dcd1455efc6a3a69cf9340e17a981286d3778615684
+        // Corresponds to address `1HnhWpkMHMjgt167kvgcPyurMmsCQ2WPgg`
+        let hash = "b8268ce4d481413c4e848ff353cd16104291c45b";
+        let hash = hash.parse::<PubkeyHash>().unwrap();
+        let desc = Descriptor::from(hash);
+        assert_eq!(desc.type_tag(), P2pkh);
+
+        let address = Address::p2pkh(hash, Network::Bitcoin);
+        let address_translated = desc.to_address(Network::Bitcoin).unwrap();
+        assert_eq!(address, address_translated);
     }
 
     #[test]

--- a/src/address.rs
+++ b/src/address.rs
@@ -14,8 +14,7 @@ use bitcoin::{
 
 use crate::{
     descriptor::{
-        P2PKH_LEN, P2PKH_TYPE_TAG, P2SH_LEN, P2SH_TYPE_TAG, P2TR_LEN, P2TR_TYPE_TAG, P2WPKH_LEN,
-        P2WPKH_P2WSH_TYPE_TAG, P2WSH_LEN,
+        P2PKH_LEN, P2SH_LEN, P2TR_LEN, P2TR_TYPE_TAG, P2WPKH_LEN, P2WPKH_P2WSH_TYPE_TAG, P2WSH_LEN,
     },
     Descriptor, DescriptorError,
     DescriptorType::*,
@@ -139,19 +138,11 @@ impl From<Address> for Descriptor {
         match address_data {
             // P2PKH
             AddressData::P2pkh { pubkey_hash } => {
-                let payload = pubkey_hash.as_raw_hash().to_byte_array();
-                let mut bytes = [0u8; 21];
-                bytes[0] = P2PKH_TYPE_TAG;
-                bytes[1..].copy_from_slice(&payload);
-                Descriptor::from_bytes(&bytes).expect("infallible")
+                Descriptor::new_p2pkh(&pubkey_hash.as_raw_hash().to_byte_array())
             }
             // P2SH
             AddressData::P2sh { script_hash } => {
-                let payload = script_hash.as_raw_hash().to_byte_array();
-                let mut bytes = [0u8; 21];
-                bytes[0] = P2SH_TYPE_TAG;
-                bytes[1..].copy_from_slice(&payload);
-                Descriptor::from_bytes(&bytes).expect("infallible")
+                Descriptor::new_p2sh(&script_hash.as_raw_hash().to_byte_array())
             }
             // SegWit V0/V1
             AddressData::Segwit { witness_program } => match witness_program.version() {
@@ -202,11 +193,7 @@ impl From<PubkeyHash> for Descriptor {
 
 impl From<ScriptHash> for Descriptor {
     fn from(script_hash: ScriptHash) -> Self {
-        let payload: &[u8; 20] = script_hash.as_ref();
-        let mut bytes = [0u8; 21];
-        bytes[0] = P2SH_TYPE_TAG;
-        bytes[1..].copy_from_slice(payload);
-        Descriptor::from_bytes(&bytes).expect("infallible")
+        Descriptor::new_p2sh(script_hash.as_ref())
     }
 }
 

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -13,6 +13,9 @@ use std::{
 
 use hex::{DisplayHex, FromHex};
 
+#[cfg(feature = "address")]
+use bitcoin::XOnlyPublicKey;
+
 use crate::error::DescriptorError;
 
 /// `OP_RETURN` type tag.
@@ -274,13 +277,21 @@ impl Descriptor {
     ///
     /// ```
     /// # use bitcoin_bosd::{Descriptor, DescriptorType, descriptor::P2TR_LEN};
-    /// let payload = [0u8; P2TR_LEN]; // all zeros, don't use in production
+    /// let payload = [2u8; P2TR_LEN]; // valid X-only public key, but don't use in production
     /// let desc = Descriptor::new_p2tr(&payload);
     /// # assert_eq!(desc.type_tag(), DescriptorType::P2tr);
-    /// # assert_eq!(desc.payload(), [0u8; P2TR_LEN]);
+    /// # assert_eq!(desc.payload(), [2u8; P2TR_LEN]);
     /// ```
     pub fn new_p2tr(payload: &[u8; P2TR_LEN]) -> Self {
         let type_tag = DescriptorType::P2tr;
+
+        // If using `rust-bitcoin` then we can validate internally the X-only public key.
+        #[cfg(feature = "address")]
+        assert!(
+            XOnlyPublicKey::from_slice(payload).is_ok(),
+            "payload is not a valid X-only public key!"
+        );
+
         Self {
             type_tag,
             payload: payload.to_vec(),
@@ -596,5 +607,13 @@ mod tests {
         let desc = Descriptor::from_str("01b8268ce4d481413c4e848ff353cd16104291c45b").unwrap();
         let bytes = desc.to_fixed_payload_bytes::<P2PKH_LEN>();
         assert_eq!(bytes.len(), P2PKH_LEN);
+    }
+
+    #[cfg(feature = "address")]
+    #[test]
+    #[should_panic(expected = "payload is not a valid X-only public key!")]
+    fn invalid_new_p2tr() {
+        let invalid_payload = [0; P2TR_LEN];
+        let _ = Descriptor::new_p2tr(&invalid_payload);
     }
 }

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -269,7 +269,7 @@ impl Descriptor {
         }
     }
 
-    /// Constructs a new [`Descriptor`] from an *unckecked* P2TR payload.
+    /// Constructs a new [`Descriptor`] from an _unchecked_ P2TR payload.
     ///
     /// The payload is expected to be a valid 32-byte X-only public key and the user should
     /// be responsible for validating the key.

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -269,32 +269,54 @@ impl Descriptor {
         }
     }
 
-    /// Constructs a new [`Descriptor`] from a P2TR payload.
+    /// Constructs a new [`Descriptor`] from an *unckecked* P2TR payload.
     ///
-    /// The payload is expected to be a valid 32-byte X-only public key.
+    /// The payload is expected to be a valid 32-byte X-only public key and the user should
+    /// be responsible for validating the key.
     ///
     /// # Example
     ///
     /// ```
     /// # use bitcoin_bosd::{Descriptor, DescriptorType, descriptor::P2TR_LEN};
     /// let payload = [2u8; P2TR_LEN]; // valid X-only public key, but don't use in production
-    /// let desc = Descriptor::new_p2tr(&payload);
+    /// let desc = Descriptor::new_p2tr_unchecked(&payload);
     /// # assert_eq!(desc.type_tag(), DescriptorType::P2tr);
     /// # assert_eq!(desc.payload(), [2u8; P2TR_LEN]);
     /// ```
-    pub fn new_p2tr(payload: &[u8; P2TR_LEN]) -> Self {
+    pub fn new_p2tr_unchecked(payload: &[u8; P2TR_LEN]) -> Self {
         let type_tag = DescriptorType::P2tr;
-
-        // If using `rust-bitcoin` then we can validate internally the X-only public key.
-        #[cfg(feature = "address")]
-        assert!(
-            XOnlyPublicKey::from_slice(payload).is_ok(),
-            "payload is not a valid X-only public key!"
-        );
 
         Self {
             type_tag,
             payload: payload.to_vec(),
+        }
+    }
+
+    /// Constructs a new [`Descriptor`] from a P2TR payload.
+    ///
+    /// The payload is expected to be a valid 32-byte X-only public key.
+    /// Otherwise the function will return an error.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bitcoin_bosd::{Descriptor, DescriptorType, descriptor::P2TR_LEN};
+    /// let payload = [2u8; P2TR_LEN]; // valid X-only public key, but don't use in production
+    /// let desc = Descriptor::new_p2tr(&payload).expect("valid X-only public key");
+    /// # assert_eq!(desc.type_tag(), DescriptorType::P2tr);
+    /// # assert_eq!(desc.payload(), [2u8; P2TR_LEN]);
+    /// ```
+    #[cfg(feature = "address")]
+    pub fn new_p2tr(payload: &[u8; P2TR_LEN]) -> Result<Self, DescriptorError> {
+        let type_tag = DescriptorType::P2tr;
+
+        if XOnlyPublicKey::from_slice(payload).is_err() {
+            Err(DescriptorError::InvalidXOnlyPublicKey)
+        } else {
+            Ok(Self {
+                type_tag,
+                payload: payload.to_vec(),
+            })
         }
     }
 
@@ -611,9 +633,13 @@ mod tests {
 
     #[cfg(feature = "address")]
     #[test]
-    #[should_panic(expected = "payload is not a valid X-only public key!")]
     fn invalid_new_p2tr() {
         let invalid_payload = [0; P2TR_LEN];
-        let _ = Descriptor::new_p2tr(&invalid_payload);
+        let result = Descriptor::new_p2tr(&invalid_payload);
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap(),
+            DescriptorError::InvalidXOnlyPublicKey
+        );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,11 @@ pub enum DescriptorError {
     #[error("invalid payload length: {0}")]
     InvalidPayloadLength(usize),
 
+    /// Invalid X-only public key.
+    #[cfg(feature = "address")]
+    #[error("invalid X-only public key")]
+    InvalidXOnlyPublicKey,
+
     /// Hex decoding error.
     #[error("hex decoding error: {0}")]
     HexDecodingError(#[from] HexToBytesError),


### PR DESCRIPTION
## Description

Feature-gated (behind `address`) X-only PK validation for the `new_p2tr` constructor.

This should be tagged as a patch release, as it is not a breaking change.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

None.