### PR TITLE
feat: drop `thiserror`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,6 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -276,26 +275,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ secp256k1 = { version = "0.29.0", optional = true, features = [ # for optimizati
   "global-context",
 ] }
 serde = { version = "1.0.219", optional = true }
-thiserror = "2.0.12"
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -54,7 +54,6 @@ dependencies = [
  "bitcoin",
  "hex-conservative",
  "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -186,18 +185,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -219,26 +218,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/src/borsh.rs
+++ b/src/borsh.rs
@@ -29,7 +29,7 @@ impl BorshDeserialize for Descriptor {
         Descriptor::from_vec(bytes).map_err(|e| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Invalid descriptor: {}", e),
+                format!("Invalid descriptor: {e}"),
             )
         })
     }

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -6,6 +6,8 @@
 //! Check this crate's top-level documentation for the
 //! specification and rationale.
 
+use core::fmt;
+
 use std::{
     fmt::{Display, Formatter},
     str::FromStr,
@@ -430,6 +432,19 @@ impl DescriptorType {
             DescriptorType::P2wpkh => 3,
             DescriptorType::P2wsh => 3,
             DescriptorType::P2tr => 4,
+        }
+    }
+}
+
+impl Display for DescriptorType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DescriptorType::OpReturn => write!(f, "OP_RETURN"),
+            DescriptorType::P2pkh => write!(f, "P2PKH"),
+            DescriptorType::P2sh => write!(f, "P2SH"),
+            DescriptorType::P2wpkh => write!(f, "P2WPKH"),
+            DescriptorType::P2wsh => write!(f, "P2WSH"),
+            DescriptorType::P2tr => write!(f, "P2TR"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,8 @@
 //! Error types for the Bitcoin BOSD library.
 
+use core::fmt;
+
 use hex::error::HexToBytesError;
-use thiserror::Error;
 
 use crate::DescriptorType;
 
@@ -11,44 +12,93 @@ use bitcoin::script::witness_program::Error as WitnessProgramError;
 use bitcoin::secp256k1::Error as Secp256k1Error;
 
 /// Errors related to [`Descriptor`](crate::Descriptor).
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum DescriptorError {
-    /// Missing type tag
-    #[error("missing type tag")]
+    /// Missing type tag.
     MissingTypeTag,
 
     /// Invalid descriptor type tag.
-    #[error("invalid descriptor type tag: {0}")]
     InvalidDescriptorType(u8),
 
     /// Invalid payload length.
-    #[error("invalid payload length: {0}")]
     InvalidPayloadLength(usize),
 
     /// Invalid X-only public key.
     #[cfg(feature = "address")]
-    #[error("invalid X-only public key")]
     InvalidXOnlyPublicKey,
 
     /// Hex decoding error.
-    #[error("hex decoding error: {0}")]
-    HexDecodingError(#[from] HexToBytesError),
+    HexDecodingError(HexToBytesError),
 
     /// Invalid [`Address`](bitcoin::Address) conversion.
     ///
     /// Currently only susceptible for `OP_RETURN` descriptors
     /// being converted to a bitcoin address.
     #[cfg(feature = "address")]
-    #[error("{0:?} cannot be converted to a bitcoin address")]
     InvalidAddressConversion(DescriptorType),
 
     /// [`secp256k1`](bitcoin::secp256k1) errors.
     #[cfg(feature = "address")]
-    #[error("secp256k1 error: {0}")]
-    Secp256k1Error(#[from] Secp256k1Error),
+    Secp256k1Error(Secp256k1Error),
 
     /// [`WitnessProgram`](bitcoin::WitnessProgram) errors.
     #[cfg(feature = "address")]
-    #[error("witness program error: {0}")]
-    WitnessProgramError(#[from] WitnessProgramError),
+    WitnessProgramError(WitnessProgramError),
+}
+
+impl core::fmt::Display for DescriptorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingTypeTag => write!(f, "missing type tag"),
+            Self::InvalidDescriptorType(tag) => write!(f, "invalid descriptor type tag: {tag}"),
+            Self::InvalidPayloadLength(len) => write!(f, "invalid payload length: {len}"),
+            #[cfg(feature = "address")]
+            Self::InvalidXOnlyPublicKey => write!(f, "invalid X-only public key"),
+            Self::HexDecodingError(err) => write!(f, "hex decoding error: {err}"),
+            #[cfg(feature = "address")]
+            Self::InvalidAddressConversion(desc_type) => write!(
+                f,
+                "{desc_type} locking script cannot be converted into a bitcoin address"
+            ),
+            #[cfg(feature = "address")]
+            Self::Secp256k1Error(err) => write!(f, "secp256k1 error: {err}"),
+            #[cfg(feature = "address")]
+            Self::WitnessProgramError(err) => write!(f, "witness program error: {err}"),
+        }
+    }
+}
+
+// TODO: uncomment feature flag when no-std is supported
+//#[cfg(feature = "std")]
+impl std::error::Error for DescriptorError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::HexDecodingError(err) => Some(err),
+            #[cfg(feature = "address")]
+            Self::Secp256k1Error(err) => Some(err),
+            #[cfg(feature = "address")]
+            Self::WitnessProgramError(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<HexToBytesError> for DescriptorError {
+    fn from(err: HexToBytesError) -> Self {
+        Self::HexDecodingError(err)
+    }
+}
+
+#[cfg(feature = "address")]
+impl From<Secp256k1Error> for DescriptorError {
+    fn from(err: Secp256k1Error) -> Self {
+        Self::Secp256k1Error(err)
+    }
+}
+
+#[cfg(feature = "address")]
+impl From<WitnessProgramError> for DescriptorError {
+    fn from(err: WitnessProgramError) -> Self {
+        Self::WitnessProgramError(err)
+    }
 }


### PR DESCRIPTION
## Description

Closes #35.

This PR drops the `thiserror` dependency by manually implementing `Display`, `Error` and `From<T>` for `DescriptorError`.

I used `core::fmt` since `no-std` support is on the roadmap.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [X] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [X] I have performed a self-review of my code.
- [X] I have commented my code where necessary.
- [X] I have updated the documentation if needed.
- [X] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [X] New and existing tests pass with my changes.
